### PR TITLE
Width of query icon panes are now the same

### DIFF
--- a/src/main/resources/ecdar/presentations/QueryPresentation.fxml
+++ b/src/main/resources/ecdar/presentations/QueryPresentation.fxml
@@ -12,7 +12,7 @@
          HBox.hgrow="ALWAYS"
          alignment="CENTER"
          fx:controller="ecdar.controllers.QueryController">
-        <VBox id="stateIndicator">
+        <VBox id="stateIndicator" alignment="CENTER">
             <padding>
                 <Insets topRightBottomLeft="10"/>
             </padding>

--- a/src/main/resources/ecdar/presentations/QueryPresentation.fxml
+++ b/src/main/resources/ecdar/presentations/QueryPresentation.fxml
@@ -16,7 +16,7 @@
             <padding>
                 <Insets topRightBottomLeft="10"/>
             </padding>
-            <Region style="-fx-max-height: 2em; -fx-min-height: 2em"/>
+            <Region style="-fx-max-height: 2em; -fx-min-height: 2em; -fx-max-width: 4em; -fx-min-width: 4em;"/>
             <StackPane styleClass="responsive-icon-stack-pane-sizing">
                 <FontIcon id="statusIcon" iconLiteral="gmi-hourglass-full" styleClass="icon-size-medium"/>
             </StackPane>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/56611129/194019177-4d66d948-9ee6-4db5-a539-37c9015bf420.png)
As querrys had diffrent sizes, half being 3em  the other half 4 em, all queries are now scaled to be 4 em wide, to fix the aligment issue.