### PR TITLE
Group 16 - Multithreaded engine utilization

### DIFF
--- a/src/main/java/ecdar/abstractions/BackendInstance.java
+++ b/src/main/java/ecdar/abstractions/BackendInstance.java
@@ -12,10 +12,12 @@ public class BackendInstance implements Serializable {
     private static final String PORT_RANGE_START = "portRangeStart";
     private static final String PORT_RANGE_END = "portRangeEnd";
     private static final String LOCKED = "locked";
+    private static final String IS_THREAD_SAFE = "isThreadSafe";
 
     private String name;
     private boolean isLocal;
     private boolean isDefault;
+    private boolean isThreadSafe;
     private String backendLocation;
     private int portStart;
     private int portEnd;
@@ -49,6 +51,14 @@ public class BackendInstance implements Serializable {
 
     public void setDefault(boolean aDefault) {
         isDefault = aDefault;
+    }
+
+    public boolean isThreadSafe() {
+        return isThreadSafe;
+    }
+
+    public void setIsThreadSafe(boolean aThreadSafe) {
+        isThreadSafe = aThreadSafe;
     }
 
     public String getBackendLocation() {
@@ -93,6 +103,7 @@ public class BackendInstance implements Serializable {
         result.addProperty(NAME, getName());
         result.addProperty(IS_LOCAL, isLocal());
         result.addProperty(IS_DEFAULT, isDefault());
+        result.addProperty(IS_THREAD_SAFE, isThreadSafe());
         result.addProperty(LOCATION, getBackendLocation());
         result.addProperty(PORT_RANGE_START, getPortStart());
         result.addProperty(PORT_RANGE_END, getPortEnd());
@@ -106,6 +117,7 @@ public class BackendInstance implements Serializable {
         setName(json.getAsJsonPrimitive(NAME).getAsString());
         setLocal(json.getAsJsonPrimitive(IS_LOCAL).getAsBoolean());
         setDefault(json.getAsJsonPrimitive(IS_DEFAULT).getAsBoolean());
+        setIsThreadSafe(json.getAsJsonPrimitive(IS_THREAD_SAFE).getAsBoolean());
         setBackendLocation(json.getAsJsonPrimitive(LOCATION).getAsString());
         setPortStart(json.getAsJsonPrimitive(PORT_RANGE_START).getAsInt());
         setPortEnd(json.getAsJsonPrimitive(PORT_RANGE_END).getAsInt());

--- a/src/main/java/ecdar/abstractions/BackendInstance.java
+++ b/src/main/java/ecdar/abstractions/BackendInstance.java
@@ -57,8 +57,8 @@ public class BackendInstance implements Serializable {
         return isThreadSafe;
     }
 
-    public void setIsThreadSafe(boolean aThreadSafe) {
-        isThreadSafe = aThreadSafe;
+    public void setIsThreadSafe(boolean threadSafe) {
+        isThreadSafe = threadSafe;
     }
 
     public String getBackendLocation() {

--- a/src/main/java/ecdar/backend/BackendDriver.java
+++ b/src/main/java/ecdar/backend/BackendDriver.java
@@ -65,12 +65,16 @@ public class BackendDriver {
                 tryStartNewBackendConnection(backend);
             }
 
-            // Block until a connection becomes available
-            connection = openBackendConnections.get(backend).take();
+            if (backend.isThreadSafe()){
+                connection = openBackendConnections.get(backend).peek();
+            }
+            else{
+                // Block until a connection becomes available
+                connection = openBackendConnections.get(backend).take();
+            }
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-
         return connection;
     }
 
@@ -105,6 +109,8 @@ public class BackendDriver {
             }
 
             do {
+                //ToDo: Refactor ProcessBuilder to accept cache-size(-cs) and thread-number(-tn) to better configure the Reveaal engine.
+                // Default values are acceptable for now.
                 ProcessBuilder pb = new ProcessBuilder(backend.getBackendLocation(), "-p", hostAddress + ":" + portNumber);
 
                 try {

--- a/src/main/java/ecdar/backend/QueryHandler.java
+++ b/src/main/java/ecdar/backend/QueryHandler.java
@@ -1,6 +1,8 @@
 package ecdar.backend;
 
 import EcdarProtoBuf.QueryProtos;
+import EcdarProtoBuf.QueryProtos.QueryRequest.Settings;
+
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import ecdar.Ecdar;
@@ -18,6 +20,7 @@ import javafx.collections.ObservableList;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 public class QueryHandler {
@@ -75,7 +78,8 @@ public class QueryHandler {
             // ToDo SW5: Not working with the updated gRPC Protos
             var queryBuilder = QueryProtos.QueryRequest.newBuilder()
                     .setUserId(1)
-                    .setQueryId(1)
+                    .setQueryId(UUID.randomUUID().hashCode())
+                    .setSettings(Settings.newBuilder().setAll(true))
                     .setQuery(query.getType().getQueryName() + ": " + query.getQuery())
                     .setComponentsInfo(componentsInfoBuilder);
 
@@ -101,117 +105,101 @@ public class QueryHandler {
         System.out.println(value);
         // If the query has been cancelled, ignore the result
         if (query.getQueryState() == QueryState.UNKNOWN) return;
-        switch (value.getResponseCase()) {
-            case QUERY_OK:
-                QueryProtos.QueryResponse.QueryOk queryOk = value.getQueryOk();
-                switch (queryOk.getResultCase()) {
-                    case REFINEMENT:
-                        if (queryOk.getRefinement().getSuccess()) {
-                            query.setQueryState(QueryState.SUCCESSFUL);
-                            query.getSuccessConsumer().accept(true);
-                        } else {
-                            query.setQueryState(QueryState.ERROR);
-                            query.getFailureConsumer().accept(new BackendException.QueryErrorException(queryOk.getRefinement().getReason()));
-                            query.getSuccessConsumer().accept(false);
-                            query.getStateActionConsumer().accept(value.getQueryOk().getRefinement().getState(),
-                                    value.getQueryOk().getRefinement().getAction());
-                        }
-                        break;
-
-                    case CONSISTENCY:
-                        if (queryOk.getConsistency().getSuccess()) {
-                            query.setQueryState(QueryState.SUCCESSFUL);
-                            query.getSuccessConsumer().accept(true);
-                        } else {
-                            query.setQueryState(QueryState.ERROR);
-                            query.getFailureConsumer().accept(new BackendException.QueryErrorException(queryOk.getConsistency().getReason()));
-                            query.getSuccessConsumer().accept(false);
-                            query.getStateActionConsumer().accept(value.getQueryOk().getConsistency().getState(),
-                                    value.getQueryOk().getConsistency().getAction());
-
-                        }
-                        break;
-
-                    case DETERMINISM:
-                        if (queryOk.getDeterminism().getSuccess()) {
-                            query.setQueryState(QueryState.SUCCESSFUL);
-                            query.getSuccessConsumer().accept(true);
-                        } else {
-                            query.setQueryState(QueryState.ERROR);
-                            query.getFailureConsumer().accept(new BackendException.QueryErrorException(queryOk.getDeterminism().getReason()));
-                            query.getSuccessConsumer().accept(false);
-                            query.getStateActionConsumer().accept(value.getQueryOk().getDeterminism().getState(),
-                                    value.getQueryOk().getDeterminism().getAction());
-
-                        }
-                        break;
-
-                    case IMPLEMENTATION:
-                        if (queryOk.getImplementation().getSuccess()) {
-                            query.setQueryState(QueryState.SUCCESSFUL);
-                            query.getSuccessConsumer().accept(true);
-                        } else {
-                            query.setQueryState(QueryState.ERROR);
-                            query.getFailureConsumer().accept(new BackendException.QueryErrorException(queryOk.getImplementation().getReason()));
-                            query.getSuccessConsumer().accept(false);
-                            //ToDo: These errors are not implemented in the Reveaal backend.
-                            query.getStateActionConsumer().accept(value.getQueryOk().getImplementation().getState(),
-                                    "");
-                        }
-                        break;
-
-                    case REACHABILITY:
-                        if (queryOk.getReachability().getSuccess()) {
-                            query.setQueryState(QueryState.SUCCESSFUL);
-                            if(value.getQueryOk().getReachability().getSuccess()){
-                                Ecdar.showToast("Reachability check was successful and the location can be reached.");
-                            }
-                            else if(!value.getQueryOk().getReachability().getSuccess()){
-                                Ecdar.showToast("Reachability check was successful but the location cannot be reached.");
-                            }
-                            query.getSuccessConsumer().accept(true);
-                        } else {
-                            query.setQueryState(QueryState.ERROR);
-                            Ecdar.showToast("Reachability check was unsuccessful!");
-                            query.getFailureConsumer().accept(new BackendException.QueryErrorException(queryOk.getReachability().getReason()));
-                            query.getSuccessConsumer().accept(false);
-                            //ToDo: These errors are not implemented in the Reveaal backend.
-                            query.getStateActionConsumer().accept(value.getQueryOk().getReachability().getState(),
-                                    "");
-                        }
-                        break;
-
-                    case COMPONENT:
+            switch (value.getResultCase()) {
+                case REFINEMENT:
+                    if (value.getRefinement().getSuccess()) {
                         query.setQueryState(QueryState.SUCCESSFUL);
                         query.getSuccessConsumer().accept(true);
-                        JsonObject returnedComponent = (JsonObject) JsonParser.parseString(queryOk.getComponent().getComponent().getJson());
-                        addGeneratedComponent(new Component(returnedComponent));
-                        break;
-
-                    case ERROR:
+                    } else {
                         query.setQueryState(QueryState.ERROR);
-                        query.getFailureConsumer().accept(new BackendException.QueryErrorException(queryOk.getError()));
+                        query.getFailureConsumer().accept(new BackendException.QueryErrorException(value.getRefinement().getReason()));
                         query.getSuccessConsumer().accept(false);
-                        break;
+                        query.getStateActionConsumer().accept(value.getRefinement().getState(),
+                        value.getRefinement().getAction());
+                    }
+                    break;
 
-                    case RESULT_NOT_SET:
+                case CONSISTENCY:
+                    if (value.getConsistency().getSuccess()) {
+                        query.setQueryState(QueryState.SUCCESSFUL);
+                        query.getSuccessConsumer().accept(true);
+                    } else {
                         query.setQueryState(QueryState.ERROR);
+                        query.getFailureConsumer().accept(new BackendException.QueryErrorException(value.getConsistency().getReason()));
                         query.getSuccessConsumer().accept(false);
-                        break;
-                }
-                break;
+                        query.getStateActionConsumer().accept(value.getConsistency().getState(),
+                                value.getConsistency().getAction());
 
-            case USER_TOKEN_ERROR:
-                query.setQueryState(QueryState.ERROR);
-                query.getFailureConsumer().accept(new BackendException.QueryErrorException(value.getUserTokenError().getErrorMessage()));
-                query.getSuccessConsumer().accept(false);
-                break;
+                    }
+                    break;
 
-            case RESPONSE_NOT_SET:
-                query.setQueryState(QueryState.ERROR);
-                query.getSuccessConsumer().accept(false);
-                break;
-        }
+                case DETERMINISM:
+                    if (value.getDeterminism().getSuccess()) {
+                        query.setQueryState(QueryState.SUCCESSFUL);
+                        query.getSuccessConsumer().accept(true);
+                    } else {
+                        query.setQueryState(QueryState.ERROR);
+                        query.getFailureConsumer().accept(new BackendException.QueryErrorException(value.getDeterminism().getReason()));
+                        query.getSuccessConsumer().accept(false);
+                        query.getStateActionConsumer().accept(value.getDeterminism().getState(),
+                                value.getDeterminism().getAction());
+
+                    }
+                    break;
+
+                case IMPLEMENTATION:
+                    if (value.getImplementation().getSuccess()) {
+                        query.setQueryState(QueryState.SUCCESSFUL);
+                        query.getSuccessConsumer().accept(true);
+                    } else {
+                        query.setQueryState(QueryState.ERROR);
+                        query.getFailureConsumer().accept(new BackendException.QueryErrorException(value.getImplementation().getReason()));
+                        query.getSuccessConsumer().accept(false);
+                        //ToDo: These errors are not implemented in the Reveaal backend.
+                        query.getStateActionConsumer().accept(value.getImplementation().getState(),
+                                "");
+                    }
+                    break;
+
+                case REACHABILITY:
+                    if (value.getReachability().getSuccess()) {
+                        query.setQueryState(QueryState.SUCCESSFUL);
+                        if(value.getReachability().getSuccess()){
+                            Ecdar.showToast("Reachability check was successful and the location can be reached.");
+                        }
+                        else if(!value.getReachability().getSuccess()){
+                            Ecdar.showToast("Reachability check was successful but the location cannot be reached.");
+                        }
+                        query.getSuccessConsumer().accept(true);
+                    } else {
+                        query.setQueryState(QueryState.ERROR);
+                        Ecdar.showToast("Reachability check was unsuccessful!");
+                        query.getFailureConsumer().accept(new BackendException.QueryErrorException(value.getReachability().getReason()));
+                        query.getSuccessConsumer().accept(false);
+                        //ToDo: These errors are not implemented in the Reveaal backend.
+                        query.getStateActionConsumer().accept(value.getReachability().getState(),
+                                "");
+                    }
+                    break;
+
+                case COMPONENT:
+                    query.setQueryState(QueryState.SUCCESSFUL);
+                    query.getSuccessConsumer().accept(true);
+                    JsonObject returnedComponent = (JsonObject) JsonParser.parseString(value.getComponent().getComponent().getJson());
+                    addGeneratedComponent(new Component(returnedComponent));
+                    break;
+
+                case ERROR:
+                    query.setQueryState(QueryState.ERROR);
+                    query.getFailureConsumer().accept(new BackendException.QueryErrorException(value.getError()));
+                    query.getSuccessConsumer().accept(false);
+                    break;
+
+                case RESULT_NOT_SET:
+                    query.setQueryState(QueryState.ERROR);
+                    query.getSuccessConsumer().accept(false);
+                    break;
+            }
     }
 
     private void handleQueryBackendError(Throwable t, Query query) {

--- a/src/main/java/ecdar/backend/SimulationHandler.java
+++ b/src/main/java/ecdar/backend/SimulationHandler.java
@@ -81,7 +81,8 @@ public class SimulationHandler {
             StreamObserver<SimulationStepResponse> responseObserver = new StreamObserver<>() {
                 @Override
                 public void onNext(QueryProtos.SimulationStepResponse value) {
-                    currentState.set(new SimulationState(value.getNewDecisionPoint()));
+                    // TODO this is temp solution to compile but should be fixed to handle ambiguity
+                    currentState.set(new SimulationState(value.getNewDecisionPoints(0)));
                     Platform.runLater(() -> traceLog.add(currentState.get()));
                 }
                 
@@ -142,7 +143,8 @@ public class SimulationHandler {
             StreamObserver<SimulationStepResponse> responseObserver = new StreamObserver<>() {
                 @Override
                 public void onNext(QueryProtos.SimulationStepResponse value) {
-                    currentState.set(new SimulationState(value.getNewDecisionPoint()));
+                    // TODO this is temp solution to compile but should be fixed to handle ambiguity
+                    currentState.set(new SimulationState(value.getNewDecisionPoints(0)));
                     Platform.runLater(() -> traceLog.add(currentState.get()));
                 }
                 

--- a/src/main/java/ecdar/controllers/BackendInstanceController.java
+++ b/src/main/java/ecdar/controllers/BackendInstanceController.java
@@ -52,6 +52,7 @@ public class BackendInstanceController implements Initializable {
     public JFXTextField portRangeStart;
     public JFXTextField portRangeEnd;
     public RadioButton defaultBackendRadioButton;
+    public RadioButton threadSafeBackendRadioButton;
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
@@ -62,6 +63,7 @@ public class BackendInstanceController implements Initializable {
             setHGrow();
 
             colorIconAsDisabledBasedOnProperty(removeBackendIcon, defaultBackendRadioButton.selectedProperty());
+            colorIconAsDisabledBasedOnProperty(removeBackendIcon, threadSafeBackendRadioButton.selectedProperty());
             colorIconAsDisabledBasedOnProperty(pickPathToBackendIcon, backendInstance.getLockedProperty());
         });
     }
@@ -93,6 +95,7 @@ public class BackendInstanceController implements Initializable {
         this.backendName.setText(instance.getName());
         this.isLocal.setSelected(instance.isLocal());
         this.defaultBackendRadioButton.setSelected(instance.isDefault());
+        this.threadSafeBackendRadioButton.setSelected(instance.isThreadSafe());
 
         // Check if the path or the address should be used
         if (isLocal.isSelected()) {
@@ -113,6 +116,7 @@ public class BackendInstanceController implements Initializable {
         backendInstance.setName(backendName.getText());
         backendInstance.setLocal(isLocal.isSelected());
         backendInstance.setDefault(defaultBackendRadioButton.isSelected());
+        backendInstance.setIsThreadSafe(threadSafeBackendRadioButton.isSelected());
         backendInstance.setBackendLocation(isLocal.isSelected() ? pathToBackend.getText() : address.getText());
         backendInstance.setPortStart(Integer.parseInt(portRangeStart.getText()));
         backendInstance.setPortEnd(Integer.parseInt(portRangeEnd.getText()));

--- a/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
+++ b/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
@@ -182,7 +182,7 @@ public class BackendOptionsDialogController implements Initializable {
         reveaal.setName("Reveaal");
         reveaal.setLocal(true);
         reveaal.setDefault(true);
-        reveaal.setPortStart(5032);
+        reveaal.setPortStart(5040);
         reveaal.setPortEnd(5040);
         reveaal.lockInstance();
         reveaal.setIsThreadSafe(true);

--- a/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
+++ b/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
@@ -185,6 +185,7 @@ public class BackendOptionsDialogController implements Initializable {
         reveaal.setPortStart(5032);
         reveaal.setPortEnd(5040);
         reveaal.lockInstance();
+        reveaal.setIsThreadSafe(true);
 
         // Load correct Reveaal executable based on OS
         List<String> potentialFilesForReveaal = new ArrayList<>();
@@ -203,6 +204,7 @@ public class BackendOptionsDialogController implements Initializable {
         jEcdar.setPortStart(5042);
         jEcdar.setPortEnd(5050);
         jEcdar.lockInstance();
+        reveaal.setIsThreadSafe(false);
 
         // Load correct j-Ecdar executable based on OS
         List<String> potentialFiledForJEcdar = new ArrayList<>();
@@ -252,10 +254,6 @@ public class BackendOptionsDialogController implements Initializable {
 
     /**
      * Add the new backend instance presentation to the backend options dialog
-<<<<<<< HEAD
-=======
-     *
->>>>>>> main
      * @param newBackendInstancePresentation The presentation of the new backend instance
      */
     private void addBackendInstancePresentationToList(BackendInstancePresentation newBackendInstancePresentation) {

--- a/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
+++ b/src/main/java/ecdar/controllers/BackendOptionsDialogController.java
@@ -204,7 +204,7 @@ public class BackendOptionsDialogController implements Initializable {
         jEcdar.setPortStart(5042);
         jEcdar.setPortEnd(5050);
         jEcdar.lockInstance();
-        reveaal.setIsThreadSafe(false);
+        jEcdar.setIsThreadSafe(false);
 
         // Load correct j-Ecdar executable based on OS
         List<String> potentialFiledForJEcdar = new ArrayList<>();

--- a/src/main/resources/ecdar/presentations/BackendInstancePresentation.fxml
+++ b/src/main/resources/ecdar/presentations/BackendInstancePresentation.fxml
@@ -94,8 +94,10 @@
                     <Region prefHeight="5"/>
                 </VBox>
             </StackPane>
-            <JFXRadioButton fx:id="defaultBackendRadioButton" styleClass="subhead">Default</JFXRadioButton>
-            <JFXRadioButton fx:id="threadSafeBackendRadioButton" styleClass="subhead">Thread Safe</JFXRadioButton>
+            <HBox spacing="20">
+                <JFXRadioButton fx:id="defaultBackendRadioButton" styleClass="subhead">Default</JFXRadioButton>
+                <JFXRadioButton fx:id="threadSafeBackendRadioButton" styleClass="subhead">Thread Safe</JFXRadioButton>
+            </HBox>
         </VBox>
     </HBox>
 </fx:root>

--- a/src/main/resources/ecdar/presentations/BackendInstancePresentation.fxml
+++ b/src/main/resources/ecdar/presentations/BackendInstancePresentation.fxml
@@ -95,6 +95,7 @@
                 </VBox>
             </StackPane>
             <JFXRadioButton fx:id="defaultBackendRadioButton" styleClass="subhead">Default</JFXRadioButton>
+            <JFXRadioButton fx:id="threadSafeBackendRadioButton" styleClass="subhead">Thread Safe</JFXRadioButton>
         </VBox>
     </HBox>
 </fx:root>

--- a/src/test/java/ecdar/simulation/SimulationTest.java
+++ b/src/test/java/ecdar/simulation/SimulationTest.java
@@ -49,7 +49,7 @@ public class SimulationTest {
                     ObjectProtos.State state = ObjectProtos.State.newBuilder().setLocationTuple(locations).build();
                     DecisionPoint decisionPoint = DecisionPoint.newBuilder().setSource(state).build();
                     QueryProtos.SimulationStepResponse response = QueryProtos.SimulationStepResponse.newBuilder()
-                            .setNewDecisionPoint(decisionPoint)
+                            .addNewDecisionPoints(decisionPoint)
                             .build();
                     responseObserver.onNext(response);
                     responseObserver.onCompleted();
@@ -84,7 +84,7 @@ public class SimulationTest {
                         .setId(comp.getInitialLocation().getId()).build();
             }
 
-            var result = stub.startSimulation(request).getNewDecisionPoint().getSource().getLocationTuple().getLocationsList().toArray();
+            var result = stub.startSimulation(request).getNewDecisionPoints(0).getSource().getLocationTuple().getLocationsList().toArray();
 
             Assertions.assertArrayEquals(expectedResponse, result);
         } catch (IOException e) {


### PR DESCRIPTION
This PR adds a backend option that determines whether an engine is thread safe.
If this option is checked only one instance of the engine will be created.
When using a threadsafe engine the port range should only be 1, i.e. the start and end port should be the same.

This change breaks compatibility if you have previously created and saved a backend. This is due to json deserialization as the old json doesnt contain the threadsafe option.
**Comment line 120 out in Abstractions/backendnstance.java.
Then on the first run add a line saying isThreadSafe = true.
After this the changes can be reverted.**

This PR is dependant on #111 