### PR TITLE
Changed thread safe option to be a checkbox

### DIFF
--- a/src/main/java/ecdar/controllers/BackendInstanceController.java
+++ b/src/main/java/ecdar/controllers/BackendInstanceController.java
@@ -52,7 +52,7 @@ public class BackendInstanceController implements Initializable {
     public JFXTextField portRangeStart;
     public JFXTextField portRangeEnd;
     public RadioButton defaultBackendRadioButton;
-    public RadioButton threadSafeBackendRadioButton;
+    public JFXCheckBox threadSafeBackendCheckBox;
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
@@ -63,7 +63,7 @@ public class BackendInstanceController implements Initializable {
             setHGrow();
 
             colorIconAsDisabledBasedOnProperty(removeBackendIcon, defaultBackendRadioButton.selectedProperty());
-            colorIconAsDisabledBasedOnProperty(removeBackendIcon, threadSafeBackendRadioButton.selectedProperty());
+            colorIconAsDisabledBasedOnProperty(removeBackendIcon, threadSafeBackendCheckBox.selectedProperty());
             colorIconAsDisabledBasedOnProperty(pickPathToBackendIcon, backendInstance.getLockedProperty());
         });
     }
@@ -95,7 +95,7 @@ public class BackendInstanceController implements Initializable {
         this.backendName.setText(instance.getName());
         this.isLocal.setSelected(instance.isLocal());
         this.defaultBackendRadioButton.setSelected(instance.isDefault());
-        this.threadSafeBackendRadioButton.setSelected(instance.isThreadSafe());
+        this.threadSafeBackendCheckBox.setSelected(instance.isThreadSafe());
 
         // Check if the path or the address should be used
         if (isLocal.isSelected()) {
@@ -116,7 +116,7 @@ public class BackendInstanceController implements Initializable {
         backendInstance.setName(backendName.getText());
         backendInstance.setLocal(isLocal.isSelected());
         backendInstance.setDefault(defaultBackendRadioButton.isSelected());
-        backendInstance.setIsThreadSafe(threadSafeBackendRadioButton.isSelected());
+        backendInstance.setIsThreadSafe(threadSafeBackendCheckBox.isSelected());
         backendInstance.setBackendLocation(isLocal.isSelected() ? pathToBackend.getText() : address.getText());
         backendInstance.setPortStart(Integer.parseInt(portRangeStart.getText()));
         backendInstance.setPortEnd(Integer.parseInt(portRangeEnd.getText()));

--- a/src/main/resources/ecdar/presentations/BackendInstancePresentation.fxml
+++ b/src/main/resources/ecdar/presentations/BackendInstancePresentation.fxml
@@ -96,7 +96,7 @@
             </StackPane>
             <HBox spacing="20">
                 <JFXRadioButton fx:id="defaultBackendRadioButton" styleClass="subhead">Default</JFXRadioButton>
-                <JFXRadioButton fx:id="threadSafeBackendRadioButton" styleClass="subhead">Thread Safe</JFXRadioButton>
+                <JFXCheckBox fx:id="threadSafeBackendCheckBox" styleClass="subhead">Thread Safe</JFXCheckBox>
             </HBox>
         </VBox>
     </HBox>


### PR DESCRIPTION
Changed thread safe option in backend controller to be a checkbox.

We thought this made more sense as it isn't a mutually exclusive option, which radio buttons often imply.
Also due to its proximity to the default button we thought it may cause confusion for the user.